### PR TITLE
Remove FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: ['https://www.sympy.org/en/donate.html']

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # .github
+
 Common GitHub files for SymPy
+
+**WARNING: If you fork this repo, it will cause these settings to apply to the
+repos under your user.**


### PR DESCRIPTION
We now have GitHub sponsors, so the NumFOCUS link is not necessary. 